### PR TITLE
Add wind farm space management scripts and documentation

### DIFF
--- a/docs/wind-farm-spaces.md
+++ b/docs/wind-farm-spaces.md
@@ -1,0 +1,319 @@
+# Wind Farm Spaces and Rooms
+
+This document lists all wind farm spaces and their associated rooms with Matrix room IDs.
+
+Generated: 2026-04-11
+
+---
+
+## Badel 2b
+
+**Space ID:** `!UKcBOSDqDrpTDSgqNU:matrix.windreserve.de`
+
+### Rooms
+
+- **Anlagenzugang | Wind Farm Access**: `!NqlWVLFuWKMyQSyKAo:matrix.windreserve.de`
+
+> Note: Turbine rooms not yet linked to space
+
+---
+
+## Boddin
+
+**Space ID:** `!JolmkGPegNnHOWyePy:matrix.windreserve.de`
+
+### Rooms
+
+- **Anlagenzugang | Wind Farm Access**: `!RtaivLvudkSoPPMulW:matrix.windreserve.de`
+- **BO1 - 16562**: `!SQqWBcnerkrXAWzPKL:matrix.windreserve.de`
+- **BO2 - 16534**: `!ToklfkyRfcDQISQgGh:matrix.windreserve.de`
+- **BO3 - 16533**: `!uYQSTGNFCfQqRWHbnm:matrix.windreserve.de`
+- **BO4 - 16481**: `!pSTiGnolNBFMROCWql:matrix.windreserve.de`
+- **BO5 - 16600**: `!BNhYWiUxHkHHYnzcrh:matrix.windreserve.de`
+
+---
+
+## Buchholz-Birkstücke
+
+**Space ID:** `!ITkJSbohbmMRCsKgoD:matrix.windreserve.de`
+
+### Rooms
+
+- **Anlagenzugang | Wind Farm Access**: `!VrafuKUEzlkvBUuMVr:matrix.windreserve.de`
+- **01 - 21421**: `!pPrCrfmlWkpSTfHsuX:matrix.windreserve.de`
+- **02 - 21422**: `!mvGTjfWqSuPrHydzbt:matrix.windreserve.de`
+
+---
+
+## Dorndorf
+
+**Space ID:** `!gyUQKVsJNjqffZNxCK:matrix.windreserve.de`
+
+### Rooms
+
+- **Anlagenzugang | Wind Farm Access**: `!DixeBgNlndDRMZSMxj:matrix.windreserve.de`
+
+> Note: Turbine rooms not yet linked to space
+
+---
+
+## Flechtdorf-Helmscheidt
+
+**Space ID:** `!sVKIrWVgKJGpKsPcCz:matrix.windreserve.de`
+
+### Rooms
+
+- **Anlagenzugang | Wind Farm Access**: `!ZmNfRUzPKNbgzrxoID:matrix.windreserve.de`
+- **S77 01 - 70282**: `!PZwNjtrJxvagCmmdqR:matrix.windreserve.de`
+- **S77 02 - 70283**: `!buhbWPBJYLnQalzICy:matrix.windreserve.de`
+- **S77 03 - 70284**: `!eweerFGuYThtjYGtjS:matrix.windreserve.de`
+- **S77 04 - 70285**: `!UsObkflhLBxoNEjnDt:matrix.windreserve.de`
+- **S77 05 - 70286**: `!timsSjZXUVqbxxPhsX:matrix.windreserve.de`
+- **NM60 01 - 70649**: `!peASDaCyYjSsRaBOFC:matrix.windreserve.de`
+- **NM60 02 - 70750**: `!SUcuBCkkFgoRbTEJqk:matrix.windreserve.de`
+
+---
+
+## Frehne Nord
+
+**Space ID:** `!woUIkHVRLLQKyNVBhH:matrix.windreserve.de`
+
+### Rooms
+
+- **Anlagenzugang | Wind Farm Access**: `!MuXxllaXRynximdUNH:matrix.windreserve.de`
+
+> Note: Turbine rooms not yet linked to space
+
+---
+
+## Frehne West
+
+**Space ID:** `!OHEMtgXFjnfDKTSDBe:matrix.windreserve.de`
+
+### Rooms
+
+- **Anlagenzugang | Wind Farm Access**: `!MELaDzDBpHYrnytvUl:matrix.windreserve.de`
+
+> Note: Turbine rooms not yet linked to space
+
+---
+
+## Giersleben
+
+**Space ID:** `!tyVfEJzJrlgbkRgshA:matrix.windreserve.de`
+
+### Rooms
+
+- **Anlagenzugang | Wind Farm Access**: `!uSgNcndXgkkhgCJTaj:matrix.windreserve.de`
+- **GIER 01 - 51089**: `!sKWPOIJkhXpSsRcUaY:matrix.windreserve.de`
+- **GIER 03 - 51076**: `!vUzVGYgwLjnGKAoHac:matrix.windreserve.de`
+- **GIER 04 - 51074**: `!ZlIIYNHFlWmfIvFAFQ:matrix.windreserve.de`
+- **GIER 07 - 51085**: `!NGUjfEsDoLKnSQayuI:matrix.windreserve.de`
+- **GIER 10 - 51075**: `!JArFLuZJaCVrRbyMwa:matrix.windreserve.de`
+- **GIER 11 - 51079**: `!zofTgeoTRwOXeCbLuf:matrix.windreserve.de`
+- **GIER 13 - 51084**: `!nkjZHSZlIowDIXrVra:matrix.windreserve.de`
+- **GIER 14 - 51083**: `!xgqPiEyjUZLTelmFSS:matrix.windreserve.de`
+- **GIER 15 - 51082**: `!UxWfLfQICrleGygMRl:matrix.windreserve.de`
+- **GIER 16 - 51081**: `!btgxXxdpPsNqIgHSfO:matrix.windreserve.de`
+- **GIER 17 - 51080**: `!FRqeTokGJfTcjeMIwx:matrix.windreserve.de`
+- **GIER 18 - 51078**: `!wLVnCglSQaJhQKVFin:matrix.windreserve.de`
+- **GIER 19 - 51077**: `!dAlqUFhaxubqFRikvK:matrix.windreserve.de`
+- **GIER 21 - 51073**: `!lIqcvmXfxacjNmEGbO:matrix.windreserve.de`
+- **GIER 22 - 51087**: `!EAhaOyJOkneKLfuliV:matrix.windreserve.de`
+
+---
+
+## Hanstedt 2
+
+**Space ID:** `!UaNESrgbzUNKsziFTV:matrix.windreserve.de`
+
+### Rooms
+
+- **Anlagenzugang | Wind Farm Access**: `!OMwzIYZPKOMNamjNSS:matrix.windreserve.de`
+
+> Note: Turbine rooms not yet linked to space
+
+---
+
+## Ohlenbüttel
+
+**Space ID:** `!OCPhxpgTRVLxyOKeav:matrix.windreserve.de`
+
+### Rooms
+
+- **Anlagenzugang | Wind Farm Access**: `!inpQcnfluZxbgWtQfa:matrix.windreserve.de`
+- **01 - 66988**: `!PrpYScMRmViRhOqbnQ:matrix.windreserve.de`
+- **02 - 66989**: `!qrOcOqNoRTxnIBCMZA:matrix.windreserve.de`
+- **03 - 66994**: `!HZXOVPudBFNHNwdrbU:matrix.windreserve.de`
+- **04 - 66996**: `!AYAVOuZNxtoesuwSpo:matrix.windreserve.de`
+- **05 - 67110**: `!NUaHHSPgCjIwtedPTC:matrix.windreserve.de`
+
+---
+
+## Oschersleben
+
+**Space ID:** `!HjxbvxgxGOdjealCHz:matrix.windreserve.de`
+
+### Rooms
+
+- **Anlagenzugang | Wind Farm Access**: `!RdkRFxfTUKMQxMTLTl:matrix.windreserve.de`
+
+> Note: Turbine rooms not yet linked to space
+
+---
+
+## Quenstedt
+
+**Space ID:** `!GPIcZRDrVorhhPqQeQ:matrix.windreserve.de`
+
+### Rooms
+
+- **Anlagenzugang | Wind Farm Access**: `!lJXwgXlfbsyRbzLVlt:matrix.windreserve.de`
+- **01 - 15533148**: `!aUfVlQBWNNVLawHdbt:matrix.windreserve.de`
+- **02 - 15533147**: `!UOxQOBgqrfoqemqHPa:matrix.windreserve.de`
+- **03 - 15533146 - Master**: `!UcjecFmCHVjMbBIInV:matrix.windreserve.de`
+- **04 - 15533145**: `!wNpJIhbRWtrurOmDfK:matrix.windreserve.de`
+
+---
+
+## Schlagsülsdorf
+
+**Space ID:** `!rpIwnHpQRWOSXMQJpq:matrix.windreserve.de`
+
+### Rooms
+
+- **Anlagenzugang | Wind Farm Access**: `!NsNRqNISHAewdfSdHx:matrix.windreserve.de`
+
+> Note: Turbine rooms not yet linked to space
+
+---
+
+## Schrepkow-Kletzke
+
+**Space ID:** `!zKaCTNrOKQWeKUYhiC:matrix.windreserve.de`
+
+### Rooms
+
+- **Anlagenzugang | Wind Farm Access**: `!GGJqOZFmApUwtXlZQo:matrix.windreserve.de`
+- **01 - V22954**: `!bfzmwxPRDUGPIJLYxD:matrix.windreserve.de`
+- **02 - V22952**: `!SmSmDwTNyBSQoxCEzF:matrix.windreserve.de`
+
+---
+
+## Silmersdorf
+
+**Space ID:** `!ihkeyOCDwkrUADhYij:matrix.windreserve.de`
+
+### Rooms
+
+- **Anlagenzugang | Wind Farm Access**: `!pcFHujFPcAYaslZDZx:matrix.windreserve.de`
+- **01 - V22188**: `!YtWkVtZTfXMcMNNacc:matrix.windreserve.de`
+- **02 - V22190**: `!fvyKgLVhzMwnAxiZHQ:matrix.windreserve.de`
+- **03 - V22191**: `!ciGWSnheJTIrgaabZU:matrix.windreserve.de`
+- **04 - V22195**: `!KRWukplpyZOhPFDwzT:matrix.windreserve.de`
+- **05 - V22196**: `!pUqGdFeCvOaaBZjMbA:matrix.windreserve.de`
+- **06 - V22197**: `!DJkGMsTxJRjjhyPUGQ:matrix.windreserve.de`
+- **07 - V22198**: `!MKVqBiHPcAkFMdEIBp:matrix.windreserve.de`
+- **08 - V22199**: `!JnmgfDozjRBupTlAfe:matrix.windreserve.de`
+
+---
+
+## Tangendorf
+
+**Space ID:** `!KlpKhRrUDuAEuoqBXK:matrix.windreserve.de`
+
+### Rooms
+
+- **Anlagenzugang | Wind Farm Access**: `!IVfOqrGEocaOgArctk:matrix.windreserve.de`
+- **TA1 - 1000-413-01**: (existing turbine room)
+- **TA2 - 1000-403-02**: (existing turbine room)
+
+---
+
+## Trinwillershagen
+
+**Space ID:** `!marRLjGLLdGubyBhop:matrix.windreserve.de`
+
+### Rooms
+
+- **Anlagenzugang | Wind Farm Access**: `!KrweLfvquoKukXkFWi:matrix.windreserve.de`
+- **01 - 15560451**: `!KqkySzWMZoGBWdzftn:matrix.windreserve.de`
+- **02 - 15560450**: `!YEpEleRhBGvvietBiU:matrix.windreserve.de`
+- **03 - 15560449**: `!cKwCxnvCArZMHoccSU:matrix.windreserve.de`
+- **04 - 15560448**: `!HXkPSgJwaDVuYmLhrN:matrix.windreserve.de`
+- **05 - 15560445 - Master**: `!ihkecomAatKXmIobib:matrix.windreserve.de`
+- **06 - 15560452**: `!NppLedmJblFDpVTXoM:matrix.windreserve.de`
+- **07 - 15560447**: `!HhmKXvCXYIyIBZZziK:matrix.windreserve.de`
+- **08 - 15560457**: `!pcUcpUkOGvKuzUCmEQ:matrix.windreserve.de`
+- **09 - 15560446**: `!JjzncqcqzKfYQMQedj:matrix.windreserve.de`
+- **10 - 15560456**: `!uwdeZUdoUYQxFuarmc:matrix.windreserve.de`
+- **11 - 15560453**: `!lzoqkIlIjcNMbrKTnW:matrix.windreserve.de`
+- **12 - 15560461**: `!TcBkOPUbmXMWsaflTU:matrix.windreserve.de`
+- **13 - 15560455**: `!dlqyhNadJjvFndhZRt:matrix.windreserve.de`
+- **14 - 15560454**: `!jRedXnwWkeTRDOgZEz:matrix.windreserve.de`
+- **15 - 15560458 - P6-Olion-Oltec-PC**: `!MCHziQcNxvaXsVBxKT:matrix.windreserve.de`
+- **16 - 15560460**: `!zcSibsAbnVsDpHWlGR:matrix.windreserve.de`
+- **17 - 15560459**: `!YASlINxvxcrejSuKAP:matrix.windreserve.de`
+
+---
+
+## Vahlbruch
+
+**Space ID:** `!dOwgqhFZBobUkMYaln:matrix.windreserve.de`
+
+### Rooms
+
+- **Anlagenzugang | Wind Farm Access**: `!hRyETiooTuoUaYRynu:matrix.windreserve.de`
+- **01 - 51089**: `!RlnrGzFpGXUjczZvCS:matrix.windreserve.de`
+- **02 - 51076**: `!ncchowsTLvuzeNNaHw:matrix.windreserve.de`
+- **03 - 51074**: `!hNAvuoSkWADOpEEVey:matrix.windreserve.de`
+
+---
+
+## Woltersdorf
+
+**Space ID:** `!sWUCxBJGqLxKYoVUXN:matrix.windreserve.de`
+
+### Rooms
+
+- **Anlagenzugang | Wind Farm Access**: `!hIipzdWQdYoBaLPPtJ:matrix.windreserve.de`
+
+> Note: Turbine rooms not yet linked to space
+
+---
+
+## Zölkow
+
+**Space ID:** `!ZQGdifJYRsfvvOUFtS:matrix.windreserve.de`
+
+### Rooms
+
+- **Anlagenzugang | Wind Farm Access**: `!LECPWRWEHhJeLsTQBj:matrix.windreserve.de`
+- **01 - 24115**: `!biGnljwZRGAbIsXkQq:matrix.windreserve.de`
+
+---
+
+## Quick Reference: Access Room IDs
+
+| Wind Farm | Access Room ID |
+|-----------|----------------|
+| Badel 2b | `!NqlWVLFuWKMyQSyKAo:matrix.windreserve.de` |
+| Boddin | `!RtaivLvudkSoPPMulW:matrix.windreserve.de` |
+| Buchholz-Birkstücke | `!VrafuKUEzlkvBUuMVr:matrix.windreserve.de` |
+| Dorndorf | `!DixeBgNlndDRMZSMxj:matrix.windreserve.de` |
+| Flechtdorf-Helmscheidt | `!ZmNfRUzPKNbgzrxoID:matrix.windreserve.de` |
+| Frehne Nord | `!MuXxllaXRynximdUNH:matrix.windreserve.de` |
+| Frehne West | `!MELaDzDBpHYrnytvUl:matrix.windreserve.de` |
+| Giersleben | `!uSgNcndXgkkhgCJTaj:matrix.windreserve.de` |
+| Hanstedt 2 | `!OMwzIYZPKOMNamjNSS:matrix.windreserve.de` |
+| Ohlenbüttel | `!inpQcnfluZxbgWtQfa:matrix.windreserve.de` |
+| Oschersleben | `!RdkRFxfTUKMQxMTLTl:matrix.windreserve.de` |
+| Quenstedt | `!lJXwgXlfbsyRbzLVlt:matrix.windreserve.de` |
+| Schlagsülsdorf | `!NsNRqNISHAewdfSdHx:matrix.windreserve.de` |
+| Schrepkow-Kletzke | `!GGJqOZFmApUwtXlZQo:matrix.windreserve.de` |
+| Silmersdorf | `!pcFHujFPcAYaslZDZx:matrix.windreserve.de` |
+| Tangendorf | `!IVfOqrGEocaOgArctk:matrix.windreserve.de` |
+| Trinwillershagen | `!KrweLfvquoKukXkFWi:matrix.windreserve.de` |
+| Vahlbruch | `!hRyETiooTuoUaYRynu:matrix.windreserve.de` |
+| Woltersdorf | `!hIipzdWQdYoBaLPPtJ:matrix.windreserve.de` |
+| Zölkow | `!LECPWRWEHhJeLsTQBj:matrix.windreserve.de` |

--- a/scripts/add-all-users-to-room.sh
+++ b/scripts/add-all-users-to-room.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Add all active users to a room or space
+# Usage: ./add-all-users-to-room.sh "ROOM_ID"
+#
+# Example:
+#   ./add-all-users-to-room.sh "!KlpKhRrUDuAEuoqBXK:matrix.windreserve.de"
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../secrets.env" 2>/dev/null || true
+source "$SCRIPT_DIR/../element-secrets.env" 2>/dev/null || true
+
+SERVER_IP="${SERVER_IP:-91.99.184.79}"
+SYNAPSE_ADMIN_USER="${SYNAPSE_ADMIN_USER:-synapse-admin}"
+SYNAPSE_ADMIN_PASS="${SYNAPSE_ADMIN_PASS:-Untwist-Jujitsu-Anguished-Slackness3}"
+
+ROOM_ID="$1"
+
+if [ -z "$ROOM_ID" ]; then
+  echo "Usage: $0 \"ROOM_ID\""
+  echo ""
+  echo "Example:"
+  echo "  $0 '!KlpKhRrUDuAEuoqBXK:matrix.windreserve.de'"
+  exit 1
+fi
+
+# Get admin token
+echo "Getting admin token..."
+TOKEN=$(ssh root@$SERVER_IP "docker exec synapse curl -s -X POST 'http://localhost:8008/_matrix/client/r0/login' -d '{\"type\":\"m.login.password\",\"user\":\"$SYNAPSE_ADMIN_USER\",\"password\":\"$SYNAPSE_ADMIN_PASS\"}'" | jq -r '.access_token')
+
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  echo "ERROR: Failed to get admin token"
+  exit 1
+fi
+
+# Make admin room admin and join
+echo "Making admin room admin..."
+ssh root@$SERVER_IP "docker exec synapse curl -s -X POST 'http://localhost:8008/_synapse/admin/v1/rooms/$ROOM_ID/make_room_admin' -H 'Authorization: Bearer $TOKEN' -H 'Content-Type: application/json' -d '{\"user_id\": \"@synapse-admin:matrix.windreserve.de\"}'" > /dev/null
+
+echo "Joining admin to room..."
+ssh root@$SERVER_IP "docker exec synapse curl -s -X POST 'http://localhost:8008/_matrix/client/r0/join/$ROOM_ID' -H 'Authorization: Bearer $TOKEN'" > /dev/null
+
+# Get all active users (excluding synapse-admin and bots)
+USERS=$(ssh root@$SERVER_IP "docker exec synapse curl -s -X GET 'http://localhost:8008/_synapse/admin/v2/users?limit=50' -H 'Authorization: Bearer $TOKEN'" | jq -r '.users[].name' | grep -v "^@synapse-admin" | grep -v "^@agentwind" | grep -v "^@agentstatus" | grep -v "^@botwindautomat" | grep -v "^@robot-n8n" | tr '\n' ' ')
+
+echo -n "Adding users to room"
+for user in $USERS; do
+  ssh root@$SERVER_IP "docker exec synapse curl -s -X POST 'http://localhost:8008/_synapse/admin/v1/join/$ROOM_ID' \
+    -H 'Authorization: Bearer $TOKEN' \
+    -H 'Content-Type: application/json' \
+    -d '{\"user_id\": \"$user\"}'" > /dev/null 2>&1
+  echo -n "."
+done
+echo " done"
+
+# Show result
+echo ""
+echo "=== Result ==="
+ssh root@$SERVER_IP "docker exec synapse curl -s 'http://localhost:8008/_synapse/admin/v1/rooms/$ROOM_ID' -H 'Authorization: Bearer $TOKEN'" | jq '{name, joined_members}'

--- a/scripts/create-room-in-space.sh
+++ b/scripts/create-room-in-space.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Create a room inside an existing space and auto-join all users
+# Usage: ./create-room-in-space.sh "SPACE_ID" "Room Name"
+#
+# Example:
+#   ./create-room-in-space.sh "!ZQGdifJYRsfvvOUFtS:matrix.windreserve.de" "Anlagenzugang | Wind Farm Access"
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../secrets.env" 2>/dev/null || true
+source "$SCRIPT_DIR/../element-secrets.env" 2>/dev/null || true
+
+SERVER_IP="${SERVER_IP:-91.99.184.79}"
+SYNAPSE_ADMIN_USER="${SYNAPSE_ADMIN_USER:-synapse-admin}"
+SYNAPSE_ADMIN_PASS="${SYNAPSE_ADMIN_PASS:-Untwist-Jujitsu-Anguished-Slackness3}"
+
+SPACE_ID="$1"
+ROOM_NAME="$2"
+
+if [ -z "$SPACE_ID" ] || [ -z "$ROOM_NAME" ]; then
+  echo "Usage: $0 \"SPACE_ID\" \"Room Name\""
+  echo ""
+  echo "Example:"
+  echo "  $0 '!ZQGdifJYRsfvvOUFtS:matrix.windreserve.de' 'Anlagenzugang | Wind Farm Access'"
+  exit 1
+fi
+
+# Get admin token
+echo "Getting admin token..."
+TOKEN=$(ssh root@$SERVER_IP "docker exec synapse curl -s -X POST 'http://localhost:8008/_matrix/client/r0/login' -d '{\"type\":\"m.login.password\",\"user\":\"$SYNAPSE_ADMIN_USER\",\"password\":\"$SYNAPSE_ADMIN_PASS\"}'" | jq -r '.access_token')
+
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  echo "ERROR: Failed to get admin token"
+  exit 1
+fi
+
+# Get all active users (excluding synapse-admin, bots, and deactivated)
+USERS=$(ssh root@$SERVER_IP "docker exec synapse curl -s -X GET 'http://localhost:8008/_synapse/admin/v2/users?limit=50&deactivated=false' -H 'Authorization: Bearer $TOKEN'" | jq -r '.users[].name' | grep -v "^@synapse-admin" | grep -v "^@agentwind" | grep -v "^@agentstatus" | grep -v "^@botwindautomat" | grep -v "^@robot-n8n")
+
+# Create room with JSON properly escaped
+echo "Creating room: $ROOM_NAME"
+ROOM_JSON=$(jq -n --arg name "$ROOM_NAME" '{"name": $name, "preset": "private_chat"}')
+ROOM_ID=$(ssh root@$SERVER_IP "docker exec synapse curl -s -X POST 'http://localhost:8008/_matrix/client/r0/createRoom' \
+  -H 'Authorization: Bearer $TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '${ROOM_JSON}'" | jq -r '.room_id')
+
+if [ -z "$ROOM_ID" ] || [ "$ROOM_ID" = "null" ]; then
+  echo "ERROR: Failed to create room"
+  exit 1
+fi
+
+echo "Room ID: $ROOM_ID"
+
+# URL-encode the space ID and room ID for the API path
+ENCODED_SPACE_ID=$(echo -n "$SPACE_ID" | jq -sRr @uri)
+ENCODED_ROOM_ID=$(echo -n "$ROOM_ID" | jq -sRr @uri)
+
+# Add room to space
+echo "Adding room to space..."
+ssh root@$SERVER_IP "docker exec synapse curl -s -X PUT 'http://localhost:8008/_matrix/client/r0/rooms/$ENCODED_SPACE_ID/state/m.space.child/$ENCODED_ROOM_ID' \
+  -H 'Authorization: Bearer $TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '{\"via\": [\"matrix.windreserve.de\"]}'" > /dev/null
+
+# Join users to room using while loop with -n flag to prevent ssh from consuming stdin
+echo -n "Joining users to room"
+ENCODED_ROOM=$(echo -n "$ROOM_ID" | jq -sRr @uri)
+while IFS= read -r user; do
+  [ -z "$user" ] && continue
+  USER_JSON=$(jq -n --arg u "$user" '{"user_id": $u}')
+  ssh -n root@$SERVER_IP "docker exec synapse curl -s -X POST 'http://localhost:8008/_synapse/admin/v1/join/$ENCODED_ROOM' \
+    -H 'Authorization: Bearer $TOKEN' \
+    -H 'Content-Type: application/json' \
+    -d '${USER_JSON}'" > /dev/null 2>&1
+  echo -n "."
+done <<< "$USERS"
+echo " done"
+
+echo ""
+echo "=== Summary ==="
+echo "Room: $ROOM_NAME"
+echo "Room ID: $ROOM_ID"
+echo "Added to Space: $SPACE_ID"

--- a/scripts/remove-bots-from-room.sh
+++ b/scripts/remove-bots-from-room.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Remove bot accounts from a room
+# Usage: ./remove-bots-from-room.sh "ROOM_ID"
+#
+# Removes these bot accounts:
+#   - @agentwind:matrix.windreserve.de
+#   - @agentstatus:matrix.windreserve.de
+#   - @botwindautomat:matrix.windreserve.de
+#   - @robot-n8n:matrix.windreserve.de
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../secrets.env" 2>/dev/null || true
+source "$SCRIPT_DIR/../element-secrets.env" 2>/dev/null || true
+
+SERVER_IP="${SERVER_IP:-91.99.184.79}"
+SYNAPSE_ADMIN_USER="${SYNAPSE_ADMIN_USER:-synapse-admin}"
+SYNAPSE_ADMIN_PASS="${SYNAPSE_ADMIN_PASS:-Untwist-Jujitsu-Anguished-Slackness3}"
+
+ROOM_ID="$1"
+
+if [ -z "$ROOM_ID" ]; then
+  echo "Usage: $0 \"ROOM_ID\""
+  echo ""
+  echo "Example:"
+  echo "  $0 '!TxAMpkGiKUmLwBkGMK:matrix.windreserve.de'"
+  exit 1
+fi
+
+# Bot accounts to remove
+BOTS=(
+  "@agentwind:matrix.windreserve.de"
+  "@agentstatus:matrix.windreserve.de"
+  "@botwindautomat:matrix.windreserve.de"
+  "@robot-n8n:matrix.windreserve.de"
+)
+
+# Get admin token
+echo "Getting admin token..."
+TOKEN=$(ssh root@$SERVER_IP "docker exec synapse curl -s -X POST 'http://localhost:8008/_matrix/client/r0/login' -d '{\"type\":\"m.login.password\",\"user\":\"$SYNAPSE_ADMIN_USER\",\"password\":\"$SYNAPSE_ADMIN_PASS\"}'" | jq -r '.access_token')
+
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  echo "ERROR: Failed to get admin token"
+  exit 1
+fi
+
+# URL-encode room ID
+ENCODED_ROOM=$(echo -n "$ROOM_ID" | jq -sRr @uri)
+
+echo "Removing bots from room..."
+for bot in "${BOTS[@]}"; do
+  ENCODED_USER=$(echo -n "$bot" | jq -sRr @uri)
+  result=$(ssh -n root@$SERVER_IP "docker exec synapse curl -s -X DELETE 'http://localhost:8008/_synapse/admin/v1/rooms/$ENCODED_ROOM/members/$ENCODED_USER' -H 'Authorization: Bearer $TOKEN'" 2>&1)
+  # Alternative: kick via state event
+  ssh -n root@$SERVER_IP "docker exec synapse curl -s -X PUT 'http://localhost:8008/_matrix/client/r0/rooms/$ENCODED_ROOM/state/m.room.member/$ENCODED_USER' \
+    -H 'Authorization: Bearer $TOKEN' \
+    -H 'Content-Type: application/json' \
+    -d '{\"membership\": \"leave\"}'" > /dev/null 2>&1
+  echo "  Removed: $bot"
+done
+
+# Show result
+echo ""
+echo "=== Result ==="
+ssh root@$SERVER_IP "docker exec synapse curl -s 'http://localhost:8008/_synapse/admin/v1/rooms/$ROOM_ID' -H 'Authorization: Bearer $TOKEN'" | jq '{name, joined_members}'

--- a/scripts/set-room-topic.sh
+++ b/scripts/set-room-topic.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Set room topic (description) for a Matrix room
+# Usage: ./set-room-topic.sh "ROOM_ID" "TOPIC"
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../secrets.env" 2>/dev/null || true
+source "$SCRIPT_DIR/../element-secrets.env" 2>/dev/null || true
+
+SERVER_IP="${SERVER_IP:-91.99.184.79}"
+SYNAPSE_ADMIN_USER="${SYNAPSE_ADMIN_USER:-synapse-admin}"
+SYNAPSE_ADMIN_PASS="${SYNAPSE_ADMIN_PASS:-Untwist-Jujitsu-Anguished-Slackness3}"
+
+ROOM_ID="$1"
+TOPIC="$2"
+
+if [ -z "$ROOM_ID" ] || [ -z "$TOPIC" ]; then
+  echo "Usage: $0 \"ROOM_ID\" \"TOPIC\""
+  echo ""
+  echo "Example:"
+  echo "  $0 '!abc123:matrix.windreserve.de' 'Wind farm location: https://maps.google.com/...'"
+  exit 1
+fi
+
+# Get admin token
+echo "Getting admin token..."
+TOKEN=$(ssh root@$SERVER_IP "docker exec synapse curl -s -X POST 'http://localhost:8008/_matrix/client/r0/login' -d '{\"type\":\"m.login.password\",\"user\":\"$SYNAPSE_ADMIN_USER\",\"password\":\"$SYNAPSE_ADMIN_PASS\"}'" | jq -r '.access_token')
+
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  echo "ERROR: Failed to get admin token"
+  exit 1
+fi
+
+echo "Setting topic for room: $ROOM_ID"
+
+# URL-encode the room ID for the API path
+ENCODED_ROOM_ID=$(echo -n "$ROOM_ID" | jq -sRr @uri)
+
+# Properly escape the topic for JSON
+JSON_PAYLOAD=$(jq -n --arg topic "$TOPIC" '{"topic": $topic}')
+
+# Set room topic using state event
+RESULT=$(ssh root@$SERVER_IP "docker exec synapse curl -s -X PUT 'http://localhost:8008/_matrix/client/r0/rooms/$ENCODED_ROOM_ID/state/m.room.topic' \
+  -H 'Authorization: Bearer $TOKEN' \
+  -H 'Content-Type: application/json' \
+  -d '$JSON_PAYLOAD'")
+
+echo "Result: $RESULT"
+
+if echo "$RESULT" | jq -e '.event_id' > /dev/null 2>&1; then
+  echo "SUCCESS: Topic set!"
+else
+  echo "ERROR: Failed to set topic"
+  echo "$RESULT"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Add scripts for managing Matrix wind farm spaces and rooms
- Document all 20 wind farm spaces with their room IDs
- Created Access rooms for 6 wind farms (Tangendorf, Frehne West, Badel 2b, Oschersleben, Hanstedt 2, Boddin)

## New Scripts

| Script | Description |
|--------|-------------|
| `create-room-in-space.sh` | Creates a room inside a space and adds all users (excluding bots) |
| `add-all-users-to-room.sh` | Adds all active users (excluding bots) to a room/space |
| `remove-bots-from-room.sh` | Removes bot accounts from rooms |
| `set-room-topic.sh` | Sets room/space topic descriptions |

## Documentation

- `docs/wind-farm-spaces.md` - Complete reference of all 20 wind farm spaces with Space IDs and Room IDs